### PR TITLE
Avoid Mixed Content, use font awesome via https

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,4 @@
-@import url(http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css);
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css);
 
 .page-header i {
     color: #94D5F5;


### PR DESCRIPTION
Could cause the icons not to show up on clients that reject mixed content.